### PR TITLE
Add `//wsl$` network path to windows mounting instructions

### DIFF
--- a/debugging/gdb/windows_mount_wsl_network_drive.md
+++ b/debugging/gdb/windows_mount_wsl_network_drive.md
@@ -6,4 +6,4 @@ TODO: expand on the instructions and test. I copypasted them from HailToDodongo 
 
 In File Explorer, go to `This PC`, click `Map network drive`, select the label (`Z:` by default), and type in `\\wsl.localhost\<distribution>` [1], then you're set
 
-[1] the beginning of the path may differ from a computer to another. I have seen some posts online with `\\wsl.$\` instead
+[1] the beginning of the path may differ from a computer to another. I have seen some posts online with `\\wsl.$\` or `\\wsl$\` instead


### PR DESCRIPTION
Hi Dragorn421,

Encountered this wsl network path scheme on Windows 11 Home with the following wsl versions.
```
WSL version: 2.3.24.0
Kernel version: 5.15.153.1-2
WSLg version: 1.0.65
MSRDC version: 1.2.5620
Direct3D version: 1.611.1-81528511
DXCore version: 10.0.26100.1-240331-1435.ge-release
Windows version: 10.0.22631.4317
```